### PR TITLE
fix: set `vault.secrets` owner to `session_user`

### DIFF
--- a/sql/supabase_vault--0.2.2.sql
+++ b/sql/supabase_vault--0.2.2.sql
@@ -19,7 +19,8 @@ DO $$
         created_at  timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at  timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP
       );
-      $f$, default_key_id);
+      ALTER TABLE vault.secrets OWNER TO %I;
+      $f$, default_key_id, session_user);
   END;
 $$;
 

--- a/supabase_vault.control
+++ b/supabase_vault.control
@@ -1,5 +1,5 @@
 comment = 'Supabase Vault Extension'
-default_version = '0.2.1'
+default_version = '0.2.2'
 relocatable = false
 schema = vault
 requires = pgsodium


### PR DESCRIPTION
This is so that pgsodium event triggers behave correctly