### PR TITLE
fix: make it possible to recreate the extension

### DIFF
--- a/sql/supabase_vault--0.2.3.sql
+++ b/sql/supabase_vault--0.2.3.sql
@@ -32,6 +32,9 @@ CREATE UNIQUE INDEX ON vault.secrets USING btree (name) WHERE name IS NOT NULL;
 SECURITY LABEL FOR pgsodium ON COLUMN vault.secrets.secret IS
 'ENCRYPT WITH KEY COLUMN key_id ASSOCIATED (id, description, created_at, updated_at) NONCE nonce';
 
+ALTER EXTENSION supabase_vault DROP VIEW vault.decrypted_secrets;
+ALTER EXTENSION supabase_vault DROP FUNCTION vault.secrets_encrypt_secret;
+
 GRANT ALL ON SCHEMA vault TO pgsodium_keyiduser;
 GRANT ALL ON TABLE vault.secrets TO pgsodium_keyiduser;
 GRANT ALL PRIVILEGES ON vault.decrypted_secrets TO pgsodium_keyiduser;

--- a/supabase_vault.control
+++ b/supabase_vault.control
@@ -1,5 +1,5 @@
 comment = 'Supabase Vault Extension'
-default_version = '0.2.2'
+default_version = '0.2.3'
 relocatable = false
 schema = vault
 requires = pgsodium


### PR DESCRIPTION
Previously recreating the extension would result in an error because there would be duplicates of default_vault_key.

Also drop extension dependency on `vault.decrypted_secrets` and `vault.secrets_encrypt_secret` so these can be regenerated without needing to drop the extension.