### PR TITLE
fix: allow secret to be an empty string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PG_CFLAGS = -std=c99 -Werror -Wno-declaration-after-statement
 EXTENSION = supabase_vault
-EXTVERSION = 0.3.0
+EXTVERSION = 0.3.1
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/sql/supabase_vault--0.3.0--0.3.1.sql
+++ b/sql/supabase_vault--0.3.0--0.3.1.sql
@@ -1,0 +1,1 @@
+-- no SQL changes in 0.3.1

--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -112,7 +112,7 @@ pgsodium_crypto_aead_det_decrypt_by_id (PG_FUNCTION_ARGS)
 	{
 		nonce = NULL;
 	}
-	ERRORIF (VARSIZE_ANY_EXHDR (ciphertext) <=
+	ERRORIF (VARSIZE_ANY_EXHDR (ciphertext) <
 		crypto_aead_det_xchacha20_ABYTES, "%s: invalid message");
 	result_len =
 		VARSIZE_ANY_EXHDR (ciphertext) - crypto_aead_det_xchacha20_ABYTES;

--- a/test/expected/test.out
+++ b/test/expected/test.out
@@ -78,9 +78,33 @@ select results_eq(
  ok 5 - bob can query an updated secret
 (1 row)
 
+truncate vault.secrets;
+reset role;
+do $$
+begin
+  perform vault.create_secret(
+    new_secret := '',
+    new_name := 'empty_secret'
+  );
+end
+$$;
+select results_eq(
+  $test$
+    select decrypted_secret collate "default"
+    from vault.decrypted_secrets
+    where name = 'empty_secret'
+  $test$,
+  $results$values ('')$results$,
+  'secret can be an empty string'
+);
+              results_eq              
+--------------------------------------
+ ok 6 - secret can be an empty string
+(1 row)
+
 select * from finish();
  finish 
 --------
- 1..5
+ 1..6
 (1 row)
 

--- a/test/expected/test.out
+++ b/test/expected/test.out
@@ -78,8 +78,8 @@ select results_eq(
  ok 5 - bob can query an updated secret
 (1 row)
 
-truncate vault.secrets;
 reset role;
+truncate vault.secrets;
 do $$
 begin
   perform vault.create_secret(

--- a/test/sql/test.sql
+++ b/test/sql/test.sql
@@ -59,8 +59,8 @@ select results_eq(
     $results$values ('fooz', 'barz', 'bazz')$results$,
      'bob can query an updated secret');
 
-truncate vault.secrets;
 reset role;
+truncate vault.secrets;
 
 do $$
 begin

--- a/test/sql/test.sql
+++ b/test/sql/test.sql
@@ -59,4 +59,26 @@ select results_eq(
     $results$values ('fooz', 'barz', 'bazz')$results$,
      'bob can query an updated secret');
 
+truncate vault.secrets;
+reset role;
+
+do $$
+begin
+  perform vault.create_secret(
+    new_secret := '',
+    new_name := 'empty_secret'
+  );
+end
+$$;
+
+select results_eq(
+  $test$
+    select decrypted_secret collate "default"
+    from vault.decrypted_secrets
+    where name = 'empty_secret'
+  $test$,
+  $results$values ('')$results$,
+  'secret can be an empty string'
+);
+
 select * from finish();


### PR DESCRIPTION
Fixes a faulty assertion that rejects decryption when the message length is 0.